### PR TITLE
Surfacing storage client expiration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -402,9 +402,10 @@ exports.getFunctionUrl = async (ctx, boundaryId, functionId) => {
 };
 
 exports.getStorageClient = (ctx) => {
+    const expiry = 60 * 16; // 15+1 min to align with Lambda lifecycle plus some buffer
     const accessToken = Jwt.sign({}, Buffer.from(ctx.configuration.fusebit_storage_key, 'base64').toString('utf8'), {
         algorithm: 'RS256',
-        expiresIn: 60 * 16, // 15+1 min to align with Lambda lifecycle plus some buffer
+        expiresIn: expiry,
         audience: ctx.configuration.fusebit_storage_audience,
         issuer: ctx.configuration.fusebit_storage_issuer_id,
         subject: ctx.configuration.fusebit_storage_subject,
@@ -416,6 +417,7 @@ exports.getStorageClient = (ctx) => {
 
     return {
         etag: null,
+        expiration: Date.now() + expiry * 1000,
         get: async function () {
             const response = await Superagent.get(url)
                 .set('Authorization', `Bearer ${accessToken}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fusebit/add-on-sdk",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fusebit/add-on-sdk",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "SDK for implementing Fusebit Add-Ons",
     "main": "lib/index.js",
     "license": "MIT",


### PR DESCRIPTION
To solve the issue we all encountered yesterday with a stale token causing 403 in the Slack connector when trying to use storage