### PR TITLE
Support for Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ debug=1 FUSE_PROFILE={profile-name} npm test
 
 ## Release Notes
 
+### v3.1.0
+
+-   Add support for converting an Express app to a Fusebit Function
+
 ### v3.0.3
 
 -   Fix bug in parameter processing in the storage client

--- a/lib/index.js
+++ b/lib/index.js
@@ -334,7 +334,7 @@ exports.createFusebitFunctionFromExpress = (app, { disableStorageClient } = {}) 
     Object.setPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(app.request)), Mock.Request.prototype);
 
     return async (ctx) => {
-        exports.debug('HTTP REQUEST', ctx.method, ctx.url, ctx.headers, ctx.body);
+        debug('HTTP REQUEST', ctx.method, ctx.url, ctx.headers, ctx.body);
 
         if (!disableStorageClient) {
             ctx.storage = await exports.createStorageClient(
@@ -344,17 +344,12 @@ exports.createFusebitFunctionFromExpress = (app, { disableStorageClient } = {}) 
             );
         }
 
-        let url = ctx.url.split('/');
-        url.splice(0, 5);
-        url = Url.parse('/' + url.join('/'));
-        url.query = ctx.query;
-        url = Url.format(url);
-
         let req = new Mock.Request({
-            url,
+            url: ctx.path,
             method: ctx.method,
             headers: ctx.headers,
         });
+        req.query = ctx.query;
         req.fusebit = ctx;
         if (ctx.body) {
             // Simulate the body had already been parsed
@@ -367,10 +362,12 @@ exports.createFusebitFunctionFromExpress = (app, { disableStorageClient } = {}) 
                 let responseFinished;
                 let res = new Mock.Response({
                     onEnd: () => {
-                        if (responseFinished) return;
+                        if (responseFinished) {
+                            return;
+                        }
                         responseFinished = true;
                         const responseBody = (res._internal.buffer || Buffer.from('')).toString('utf8');
-                        exports.debug('HTTP RESPONSE', res.statusCode, responseBody);
+                        debug('HTTP RESPONSE', res.statusCode, responseBody);
                         process.nextTick(() => {
                             resolve({
                                 body: responseBody,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const Superagent = require('superagent');
 const Url = require('url');
+const Mock = require('mock-http');
 
 function debug() {
     if (+process.env.debug) {
@@ -325,4 +326,66 @@ exports.createStorageClient = async (ctx, accessToken, storageIdPrefix) => {
     };
 
     return storageClient;
+};
+
+exports.createFusebitFunctionFromExpress = (app, { disableStorageClient } = {}) => {
+    // See https://github.com/fusebit/samples/blob/master/express/index.js#L6
+    Object.setPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(app.response)), Mock.Response.prototype);
+    Object.setPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(app.request)), Mock.Request.prototype);
+
+    return async (ctx) => {
+        exports.debug('HTTP REQUEST', ctx.method, ctx.url, ctx.headers, ctx.body);
+
+        if (!disableStorageClient) {
+            ctx.storage = await exports.createStorageClient(
+                ctx,
+                ctx.fusebit.functionAccessToken,
+                `boundary/${ctx.boundaryId}/function/${ctx.functionId}/root`
+            );
+        }
+
+        let url = ctx.url.split('/');
+        url.splice(0, 5);
+        url = Url.parse('/' + url.join('/'));
+        url.query = ctx.query;
+        url = Url.format(url);
+
+        let req = new Mock.Request({
+            url,
+            method: ctx.method,
+            headers: ctx.headers,
+        });
+        req.fusebit = ctx;
+        if (ctx.body) {
+            // Simulate the body had already been parsed
+            req._body = true;
+            req.body = ctx.body;
+        }
+
+        return new Promise((resolve, reject) => {
+            try {
+                let responseFinished;
+                let res = new Mock.Response({
+                    onEnd: () => {
+                        if (responseFinished) return;
+                        responseFinished = true;
+                        const responseBody = (res._internal.buffer || Buffer.from('')).toString('utf8');
+                        exports.debug('HTTP RESPONSE', res.statusCode, responseBody);
+                        process.nextTick(() => {
+                            resolve({
+                                body: responseBody,
+                                bodyEncoding: 'utf8',
+                                headers: res._internal.headers,
+                                status: res.statusCode,
+                            });
+                        });
+                    },
+                });
+
+                app.handle(req, res);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fusebit/add-on-sdk",
-    "version": "3.0.3",
+    "version": "3.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -793,6 +793,16 @@
             "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
             "dev": true
         },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "dev": true,
+            "requires": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -894,6 +904,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
             "dev": true
         },
         "array-unique": {
@@ -1087,6 +1103,47 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                }
+            }
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1125,6 +1182,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
             "dev": true
         },
         "cache-base": {
@@ -1289,6 +1352,29 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
+        "content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
         "convert-source-map": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -1305,6 +1391,18 @@
                     "dev": true
                 }
             }
+        },
+        "cookie": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "dev": true
         },
         "cookiejar": {
             "version": "2.1.2",
@@ -1471,6 +1569,18 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
         "detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1510,6 +1620,12 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
         "emittery": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -1520,6 +1636,12 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
         },
         "end-of-stream": {
@@ -1539,6 +1661,12 @@
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -1575,6 +1703,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
         "exec-sh": {
@@ -1666,6 +1800,73 @@
                 "jest-matcher-utils": "^26.6.2",
                 "jest-message-util": "^26.6.2",
                 "jest-regex-util": "^26.0.0"
+            }
+        },
+        "express": {
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "~1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1807,6 +2008,38 @@
                 "to-regex-range": "^5.0.1"
             }
         },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
         "find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1844,6 +2077,12 @@
             "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
             "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
         },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
+        },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1852,6 +2091,12 @@
             "requires": {
                 "map-cache": "^0.2.2"
             }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -2050,6 +2295,27 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
+        "http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2111,6 +2377,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
             "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true
         },
         "is-accessor-descriptor": {
@@ -3086,11 +3358,28 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
+        },
+        "mergee": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mergee/-/mergee-1.0.0.tgz",
+            "integrity": "sha512-hbbXD4LOcxVkpS+mp3BMEhkSDf+lTVENFeEeqACgjjL8WrgKuW2EyLT0fOHyTbyDiuRLZJZ1HrHNeiX4iOd79Q=="
         },
         "methods": {
             "version": "1.1.2",
@@ -3167,6 +3456,14 @@
                 }
             }
         },
+        "mock-http": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mock-http/-/mock-http-1.1.0.tgz",
+            "integrity": "sha512-H2HMGaHNQPWY8PdeEw4RFux2WEOHD6eJAtN3+iFELik5kGjPKAcoyPWcsC2vgDiTa2yimAEDssmMed51e+cBKQ==",
+            "requires": {
+                "mergee": "^1.0.0"
+            }
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3195,6 +3492,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
         },
         "nice-try": {
@@ -3336,6 +3639,15 @@
                 "isobject": "^3.0.1"
             }
         },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3422,6 +3734,12 @@
             "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
             "dev": true
         },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true
+        },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -3450,6 +3768,12 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
             "dev": true
         },
         "performance-now": {
@@ -3522,6 +3846,16 @@
                 "sisteransi": "^1.0.5"
             }
         },
+        "proxy-addr": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+            "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+            "dev": true,
+            "requires": {
+                "forwarded": "~0.1.2",
+                "ipaddr.js": "1.9.1"
+            }
+        },
         "psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -3548,6 +3882,24 @@
             "version": "6.9.4",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
             "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            }
         },
         "react-is": {
             "version": "17.0.1",
@@ -3961,6 +4313,70 @@
                 "lru-cache": "^6.0.0"
             }
         },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
+            }
+        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -3989,6 +4405,12 @@
                     }
                 }
             }
+        },
+        "setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+            "dev": true
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -4294,6 +4716,12 @@
                 }
             }
         },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
+        },
         "stealthy-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -4479,6 +4907,12 @@
                 "is-number": "^7.0.0"
             }
         },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
         "tough-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -4535,6 +4969,16 @@
             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
+        "type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            }
+        },
         "typedarray-to-buffer": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -4555,6 +4999,12 @@
                 "is-extendable": "^0.1.1",
                 "set-value": "^2.0.1"
             }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
         },
         "unset-value": {
             "version": "1.0.0",
@@ -4622,6 +5072,12 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4656,6 +5112,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fusebit/add-on-sdk",
-    "version": "3.0.3",
+    "version": "3.1.0",
     "description": "SDK for implementing Fusebit Add-Ons",
     "main": "lib/index.js",
     "license": "MIT",
@@ -8,13 +8,15 @@
     "packageAs": "@fusebit/add-on-sdk",
     "keywords": [],
     "dependencies": {
-        "superagent": "^6.1.0"
+        "superagent": "^6.1.0",
+        "mock-http": "1.1.0"
     },
     "devDependencies": {
         "node-notifier": ">=8.0.1",
         "prettier": "^2.0.5",
         "jest": "^26.6.3",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "express": "4.17.1"
     },
     "scripts": {
         "test": "jest --colors",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -121,6 +121,7 @@ const expressGetCtx = {
     method: 'GET',
     baseUrl: 'https://api.fusebit.io/v1/run/subscription/boundary/function/test',
     url: '/run/subscription/boundary/function/test',
+    path: '/test',
     query: {
         a: '1',
         b: '2',
@@ -137,6 +138,7 @@ const expressPostCtx = {
     method: 'POST',
     baseUrl: 'https://api.fusebit.io/v1/run/subscription/boundary/function/test',
     url: '/run/subscription/boundary/function/test',
+    path: '/test',
     query: {
         a: '1',
         b: '2',
@@ -159,6 +161,7 @@ const expressPostCtxCtx = {
     method: 'POST',
     baseUrl: 'https://api.fusebit.io/v1/run/subscription/boundary/function/test-ctx',
     url: '/run/subscription/boundary/function/test-ctx',
+    path: '/test-ctx',
     query: {
         a: '1',
         b: '2',


### PR DESCRIPTION
This adds a createFusebitFunctionFromExpress which allows fusebit functions to be authored as express apps. Just lifting this from the connector implementations to sdk since now it is used in msteams, oauth, and going forward slack. 